### PR TITLE
fix: respect channel mute in background and push notification paths

### DIFF
--- a/lib/services/notifications/push_notification_service.dart
+++ b/lib/services/notifications/push_notification_service.dart
@@ -291,6 +291,19 @@ class PushNotificationService {
       if (!masterEnabled) return;
       if (pushType == 'channel_message') {
         if (!(prefs.getBool('channel_notifications_enabled') ?? true)) return;
+
+        // Respect per-channel mute preference.
+        final channelStr = message.data['channel'] as String?;
+        final channelIndex =
+            channelStr != null ? int.tryParse(channelStr) : null;
+        if (channelIndex != null) {
+          final mutedRaw = prefs.getStringList('muted_channel_indices');
+          if (mutedRaw != null) {
+            final mutedSet =
+                mutedRaw.map((s) => int.tryParse(s)).whereType<int>().toSet();
+            if (mutedSet.contains(channelIndex)) return;
+          }
+        }
       } else {
         if (!(prefs.getBool('dm_notifications_enabled') ?? true)) return;
       }

--- a/lib/services/transport/background_message_processor.dart
+++ b/lib/services/transport/background_message_processor.dart
@@ -427,6 +427,23 @@ class BackgroundMessageProcessor {
         if (!(prefs.getBool(_kBgDmToggle) ?? true)) return;
       }
 
+      // Respect per-channel mute (same SharedPreferences key used by
+      // MutedChannelsNotifier on the foreground side).
+      if (isChannelMessage) {
+        final mutedRaw = prefs.getStringList('muted_channel_indices');
+        if (mutedRaw != null) {
+          final mutedSet =
+              mutedRaw.map((s) => int.tryParse(s)).whereType<int>().toSet();
+          if (mutedSet.contains(message.channel)) {
+            AppLogging.ble(
+              'BackgroundMessageProcessor: channel ${message.channel} is '
+              'muted, skipping notification',
+            );
+            return;
+          }
+        }
+      }
+
       final ns = NotificationService();
       final displayName =
           senderLongName ?? '!${message.from.toRadixString(16).toUpperCase()}';


### PR DESCRIPTION
## Summary
- **Background processor** (`background_message_processor.dart`) and **FCM push handler** (`push_notification_service.dart`) now check the `muted_channel_indices` SharedPreferences key before showing a notification
- Previously, muting a channel only suppressed notifications in the foreground path (`app_providers.dart`), so muted channels still fired notifications when the app was backgrounded or received a push
- Messages are still persisted regardless of mute state — only the visible notification is suppressed

## Test plan
- [ ] Mute a channel via the channel options sheet
- [ ] Send a message to that channel while the app is in the foreground — no notification should appear
- [ ] Send a message to that channel while the app is backgrounded (BLE connection) — no notification should appear
- [ ] Send a push notification for that channel via FCM — no notification should appear
- [ ] Unmute the channel and verify notifications resume in all three paths
- [ ] Verify messages are still persisted to the database while muted

Fixes #73

🤖 Generated with [Claude Code](https://claude.com/claude-code)