### PR TITLE
feat(map): increase live map zoom to 21

### DIFF
--- a/lib/core/map_config.dart
+++ b/lib/core/map_config.dart
@@ -29,13 +29,16 @@ class MapConfig {
   static const double minZoom = 3.0;
   static const double maxZoom = 18.0;
 
+  /// Deepest tile level verified to return real imagery everywhere tested.
+  static const int verifiedNativeZoomCap = 18;
+
   /// Maximum interactive zoom for the live mesh map. Deep enough to place a
   /// tracker on a single building or yard, which z18 cannot. Tile sources
-  /// that stop short of this (see [MapTileStyle.maxNativeZoom]) overzoom
-  /// their last real tiles rather than requesting ones the server does not
-  /// have. Deliberately separate from [maxZoom] so the offline downloader's
-  /// tile budget does not grow with the camera ceiling.
-  static const double liveMapMaxZoom = 20.0;
+  /// that stop short of this overzoom their last real tiles rather than
+  /// requesting provider placeholders; fallback sources are capped at
+  /// [verifiedNativeZoomCap]. Deliberately separate from [maxZoom] so the
+  /// offline downloader's tile budget does not grow with the camera ceiling.
+  static const double liveMapMaxZoom = 21.0;
 
   /// Minimum interactive zoom for the live mesh map. Kept low enough that
   /// "fit all" can zoom out to frame globally-distributed nodes: a radio with
@@ -168,6 +171,7 @@ class MapConfig {
     return TileLayer(
       urlTemplate: satelliteReferenceLabelsUrl,
       userAgentPackageName: userAgentPackageName,
+      maxNativeZoom: verifiedNativeZoomCap,
       // Reference layer has no @2x assets; matching base satellite retina off.
       retinaMode: false,
       evictErrorTileStrategy: EvictErrorTileStrategy.dispose,
@@ -310,13 +314,13 @@ class MapConfig {
   }) =>
       urlForStyle(style, satelliteLabelsOn: satelliteLabelsOn).contains('{r}');
 
-  /// Highest zoom the resolved source actually serves. Mapbox styles serve
-  /// deeper than the interaction cap; MapTiler Outdoor serves to z22 so its
-  /// terrain no longer overzooms at the old z17 native cap.
+  /// Highest zoom requested from the resolved source. Fallback sources stop at
+  /// the deepest globally verified level and overzoom beyond it; keyed
+  /// MapTiler Outdoor terrain has been verified through z20.
   static int maxNativeZoomForStyle(MapTileStyle style) {
-    if (isMapboxActive) return 18;
+    if (isMapboxActive) return verifiedNativeZoomCap;
     if (style == MapTileStyle.terrain && isMaptilerActive) return 20;
-    return style.maxNativeZoom;
+    return style.maxNativeZoom.clamp(0, verifiedNativeZoomCap);
   }
 
   /// Attribution label for the resolved source.

--- a/lib/features/map/map_screen.dart
+++ b/lib/features/map/map_screen.dart
@@ -298,7 +298,14 @@ class _MapScreenState extends ConsumerState<MapScreen>
     }
   }
 
-  double _currentZoom = 14.0;
+  final ValueNotifier<double> _mapZoomNotifier = ValueNotifier<double>(14.0);
+  double get _currentZoom => _mapZoomNotifier.value;
+  set _currentZoom(double value) {
+    if (value.isFinite && value != _mapZoomNotifier.value) {
+      _mapZoomNotifier.value = value;
+    }
+  }
+
   bool _showNodeList = false;
   bool _showFilters = false;
   bool _measureMode = false;
@@ -422,6 +429,7 @@ class _MapScreenState extends ConsumerState<MapScreen>
     _searchController.dispose();
     _takSearchController.dispose();
     _mapRotationNotifier.dispose();
+    _mapZoomNotifier.dispose();
     _elevationService = null;
     super.dispose();
   }
@@ -1982,6 +1990,7 @@ class _MapScreenState extends ConsumerState<MapScreen>
                           position.center,
                           position.zoom,
                         )) {
+                          _currentZoom = position.zoom;
                           _lastFiniteCenter = position.center;
                           _lastFiniteZoom = position.zoom;
                           // Remember the pose for the app session so returning
@@ -2020,12 +2029,10 @@ class _MapScreenState extends ConsumerState<MapScreen>
                               );
                             }
                           }
-                          // No setState: rotation flows through the notifier
-                          // (compass-only rebuild) and zoom is read on the
-                          // next data/selection-triggered build. Avoiding a
-                          // per-frame screen rebuild during pan/rotate.
+                          // No setState: rotation and zoom flow through their
+                          // controls-only notifiers, avoiding a per-frame
+                          // screen rebuild during pan/rotate.
                           _mapRotation = position.rotation;
-                          _currentZoom = position.zoom;
                         }
                       },
                       onTap: (tapPos, point) {
@@ -2864,61 +2871,69 @@ class _MapScreenState extends ConsumerState<MapScreen>
                         ),
                       ),
                     ),
-                  // Map controls — wrapped in ValueListenableBuilder so the
-                  // compass needle redraws on rotation changes without
-                  // rebuilding the whole screen.
+                  // Zoom and rotation redraw only the controls subtree,
+                  // without rebuilding the whole map screen.
                   ValueListenableBuilder<double>(
-                    valueListenable: _mapRotationNotifier,
-                    builder: (context, rotation, _) {
-                      return MapControlsOverlay(
-                        currentZoom: _currentZoom,
-                        minZoom: MapConfig.liveMapMinZoom,
-                        maxZoom: MapConfig.liveMapMaxZoom,
-                        mapRotation: rotation,
-                        isHeadingUp: _headingUpMode,
-                        compassMode: _compassMode,
-                        onZoomIn: () {
-                          final newZoom = (_currentZoom + 1).clamp(
-                            MapConfig.liveMapMinZoom,
-                            MapConfig.liveMapMaxZoom,
-                          );
-                          _animatedMove(_mapController.camera.center, newZoom);
-                          HapticFeedback.selectionClick();
-                        },
-                        onZoomOut: () {
-                          final newZoom = (_currentZoom - 1).clamp(
-                            MapConfig.liveMapMinZoom,
-                            MapConfig.liveMapMaxZoom,
-                          );
-                          _animatedMove(_mapController.camera.center, newZoom);
-                          HapticFeedback.selectionClick();
-                        },
-                        onFitAll: () => _fitAllNodes(nodesWithPosition),
-                        onCenterOnMe: () =>
-                            _centerOnMyNode(nodesWithPosition, myNodeNum),
-                        onResetNorth: _onCompassTap,
-                        hasMyLocation: nodesWithPosition.any(
-                          (n) => n.node.nodeNum == myNodeNum,
-                        ),
-                        onLocationUnavailable: () {
-                          final navigator = Navigator.of(context);
-                          showActionSnackBar(
-                            context,
-                            'No position available. Enable GPS on your device or turn on "Provide phone location" in Settings.', // lint-allow: hardcoded-string
-                            actionLabel: context.l10n.actionView,
-                            onAction: () => navigator.push(
-                              MaterialPageRoute(
-                                builder: (_) => const SettingsScreen(
-                                  initialSearchQuery: 'phone location',
+                    valueListenable: _mapZoomNotifier,
+                    builder: (context, currentZoom, _) {
+                      return ValueListenableBuilder<double>(
+                        valueListenable: _mapRotationNotifier,
+                        builder: (context, rotation, _) => MapControlsOverlay(
+                          currentZoom: currentZoom,
+                          minZoom: MapConfig.liveMapMinZoom,
+                          maxZoom: MapConfig.liveMapMaxZoom,
+                          mapRotation: rotation,
+                          isHeadingUp: _headingUpMode,
+                          compassMode: _compassMode,
+                          onZoomIn: () {
+                            final newZoom = (currentZoom + 1).clamp(
+                              MapConfig.liveMapMinZoom,
+                              MapConfig.liveMapMaxZoom,
+                            );
+                            _animatedMove(
+                              _mapController.camera.center,
+                              newZoom,
+                            );
+                            HapticFeedback.selectionClick();
+                          },
+                          onZoomOut: () {
+                            final newZoom = (currentZoom - 1).clamp(
+                              MapConfig.liveMapMinZoom,
+                              MapConfig.liveMapMaxZoom,
+                            );
+                            _animatedMove(
+                              _mapController.camera.center,
+                              newZoom,
+                            );
+                            HapticFeedback.selectionClick();
+                          },
+                          onFitAll: () => _fitAllNodes(nodesWithPosition),
+                          onCenterOnMe: () =>
+                              _centerOnMyNode(nodesWithPosition, myNodeNum),
+                          onResetNorth: _onCompassTap,
+                          hasMyLocation: nodesWithPosition.any(
+                            (n) => n.node.nodeNum == myNodeNum,
+                          ),
+                          onLocationUnavailable: () {
+                            final navigator = Navigator.of(context);
+                            showActionSnackBar(
+                              context,
+                              'No position available. Enable GPS on your device or turn on "Provide phone location" in Settings.', // lint-allow: hardcoded-string
+                              actionLabel: context.l10n.actionView,
+                              onAction: () => navigator.push(
+                                MaterialPageRoute(
+                                  builder: (_) => const SettingsScreen(
+                                    initialSearchQuery: 'phone location',
+                                  ),
                                 ),
                               ),
-                            ),
-                            type: SnackBarType.warning,
-                          );
-                        },
-                        showFitAll: true,
-                        showNavigation: true,
-                        showCompass: true,
+                              type: SnackBarType.warning,
+                            );
+                          },
+                          showFitAll: true,
+                          showNavigation: true,
+                          showCompass: true,
+                        ),
                       );
                     },
                   ),

--- a/test/core/map_config_test.dart
+++ b/test/core/map_config_test.dart
@@ -140,7 +140,8 @@ void main() {
       expect(MapConfig.defaultZoom, 13.0);
       expect(MapConfig.minZoom, 3.0);
       expect(MapConfig.maxZoom, 18.0);
-      expect(MapConfig.liveMapMaxZoom, 20.0);
+      expect(MapConfig.verifiedNativeZoomCap, 18);
+      expect(MapConfig.liveMapMaxZoom, 21.0);
     });
 
     test('live camera range encloses the offline download window', () {
@@ -307,9 +308,12 @@ void main() {
         );
       });
 
-      test('maxNativeZoomForStyle returns the raw native cap', () {
+      test('maxNativeZoomForStyle caps fallback tile requests', () {
         for (final style in MapTileStyle.values) {
-          expect(MapConfig.maxNativeZoomForStyle(style), style.maxNativeZoom);
+          expect(
+            MapConfig.maxNativeZoomForStyle(style),
+            style.maxNativeZoom.clamp(0, MapConfig.verifiedNativeZoomCap),
+          );
         }
       });
 
@@ -415,7 +419,7 @@ void main() {
         expect(url, endsWith('{r}.png?key=abc123'));
       });
 
-      test('keyed dark / light keep subdomains, retina and native zoom', () {
+      test('keyed dark / light keep subdomains, retina and capped zoom', () {
         dotenv.loadFromString(envString: 'CARTO_API_KEY=abc123');
         expect(MapConfig.subdomainsForStyle(MapTileStyle.dark), [
           'a',
@@ -432,7 +436,7 @@ void main() {
         );
         expect(
           MapConfig.maxNativeZoomForStyle(MapTileStyle.light),
-          MapTileStyle.light.maxNativeZoom,
+          MapConfig.verifiedNativeZoomCap,
         );
       });
 
@@ -525,10 +529,11 @@ void main() {
         expect(MapConfig.satelliteReferenceLabelsAttribution, '© Esri');
       });
 
-      test('factory builds a TileLayer with the overlay url', () {
+      test('factory builds a TileLayer capped at the verified native zoom', () {
         final overlay = MapConfig.satelliteReferenceLabelsTileLayer();
         expect(overlay, isNotNull);
         expect(overlay.urlTemplate, MapConfig.satelliteReferenceLabelsUrl);
+        expect(overlay.maxNativeZoom, MapConfig.verifiedNativeZoomCap);
       });
     });
   });


### PR DESCRIPTION
Issue #315 
Keep zoom controls in sync with camera movement and overzoom tiles beyond each provider native limit.

Provider limits used by the live map:
- Mapbox styles: z18
- MapTiler Outdoor terrain: z20
- CARTO dark/light: request through z18 (source declares z20)
- Esri World Imagery: request through z18 (source declares z19)
- OpenTopoMap terrain: z17
- Esri satellite reference labels: z18

The interactive map overzooms these sources through z21.